### PR TITLE
adds example of lazy form validation required by the programme

### DIFF
--- a/src/app/components/common/form-validation/form-validation.module.js
+++ b/src/app/components/common/form-validation/form-validation.module.js
@@ -1,0 +1,9 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('idam-common.form-validation', [
+            'idam-common.form-validation.lazy-validation',
+            'idam-common.form-validation.lazy-validation-on-click'
+        ]);
+})();

--- a/src/app/components/common/form-validation/lazy-validation-on-click.directive.js
+++ b/src/app/components/common/form-validation/lazy-validation-on-click.directive.js
@@ -1,0 +1,41 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('idam-common.form-validation.lazy-validation-on-click', [
+            'idam-common.form-validation.lazy-validation'
+        ])
+        .directive('lazyValidationOnClick', lazyValidationOnClick);
+
+    /**
+     * This directive triggers revalidation of a form on a click event
+     *
+     * <form lazy-validation="scopePropertyToBindFormValidation">
+     *     <button lazy-validation-on-click="optionalCallbackWhenFormValid()" />
+     * </form>
+     */
+    function lazyValidationOnClick() {
+        return {
+            restrict: 'A',
+            require: '^^lazyValidation',
+            /** Makes sure postLink runs before ng-click */
+            priority: '-1',
+            link: function ($scope, element, attrs, lazyValidationController) {
+                var revalidateAndRunCallbackIfDefined = function () {
+                    lazyValidationController.revalidate();
+
+                    if (lazyValidationController.isValid() && $scope.ifValidCallback) {
+                        $scope.ifValidCallback();
+                    }
+                };
+
+                element.bind('click', function () {
+                    $scope.$apply(revalidateAndRunCallbackIfDefined);
+                });
+            },
+            scope: {
+                ifValidCallback: '&?lazyValidationOnClick'
+            }
+        };
+    }
+})();

--- a/src/app/components/common/form-validation/lazy-validation.directive.js
+++ b/src/app/components/common/form-validation/lazy-validation.directive.js
@@ -1,0 +1,47 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('idam-common.form-validation.lazy-validation', [])
+        .directive('lazyValidation', lazyValidation);
+
+    /**
+     * Lazy Validation
+     *
+     * It wraps default angular validation which is dynamic in it's nature
+     * and delays its execution till it's explicitly required
+     * (eg. when user clicks on a form's 'Submit' button)
+     *
+     * <form lazy-validation="formName">
+     *     <span ng-if="formName.name.$error.required">Name is required</span>
+     *     <input type=text name="name">
+     *
+     *     <button lazy-validation-on-click></button>
+     * </form>
+     */
+    function lazyValidation() {
+        function createDeepCopy(validationData) {
+            return angular.copy(validationData);
+        }
+
+        return {
+            restrict: 'A',
+            require: 'form',
+            controller: ['$scope', function ($scope) {
+                this.revalidate = function () {
+                    $scope.validation = createDeepCopy($scope.angularFormController);
+                };
+
+                this.isValid = function () {
+                    return $scope.angularFormController.$valid;
+                };
+            }],
+            link: function ($scope, element, attrs, angularFormController) {
+                $scope.angularFormController = angularFormController;
+            },
+            scope: {
+                validation: '=lazyValidation'
+            }
+        };
+    }
+})();

--- a/src/app/components/common/form-validation/test/lazy-validation-on-click.spec.js
+++ b/src/app/components/common/form-validation/test/lazy-validation-on-click.spec.js
@@ -1,0 +1,137 @@
+(function () {
+    'use strict';
+
+    describe('lazy-validation-on-click directive', function () {
+        var lazyValidationController, $compile, $scope, template, buttonElem;
+
+        function compileDirective(template) {
+            mockDirectiveController(
+                'lazyValidation',
+                lazyValidationController,
+                template
+            );
+
+            return $compile(template)($scope);
+        }
+
+        function mockDirectiveController(directiveName, controller, element) {
+            element.data('$' + directiveName + 'Controller', controller);
+            return element;
+        }
+
+        beforeEach(module('idam-common.form-validation.lazy-validation-on-click'));
+
+        beforeEach(inject(function (_$rootScope_, _$compile_) {
+            $scope = _$rootScope_.$new();
+            $compile = _$compile_;
+
+            lazyValidationController = {
+                revalidate: jasmine.createSpy('revalidate'),
+                isValid: jasmine.createSpy('isValid')
+            };
+        }));
+
+        describe('when callback attribute has been set', function () {
+            beforeEach(function () {
+                template = angular.element('<div><button lazy-validation-on-click="callback()"></button></div>');
+                $scope.callback = jasmine.createSpy('callback');
+
+                buttonElem = compileDirective(template).find('button');
+            });
+
+            describe('and form was valid', function () {
+                beforeEach(function () {
+                    lazyValidationController.isValid = jasmine
+                        .createSpy('isValid')
+                        .and
+                        .returnValue(true);
+                });
+
+                describe('and element has been clicked', function () {
+                    beforeEach(function () {
+                        buttonElem.triggerHandler('click');
+                    });
+
+                    it('should revalidate the form', function () {
+                        expect(lazyValidationController.revalidate).toHaveBeenCalled();
+                    });
+
+                    it('should trigger the callback', function () {
+                        expect($scope.callback).toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe('and form was NOT valid', function () {
+                beforeEach(function () {
+                    lazyValidationController.isValid = jasmine
+                        .createSpy('isValid')
+                        .and
+                        .returnValue(false);
+                });
+
+                describe('and element has been clicked', function () {
+                    beforeEach(function () {
+                        buttonElem.triggerHandler('click');
+                    });
+
+                    it('should revalidate the form', function () {
+                        expect(lazyValidationController.revalidate).toHaveBeenCalled();
+                    });
+
+                    it('should NOT trigger the callback', function () {
+                        expect($scope.callback).not.toHaveBeenCalled();
+                    });
+                });
+
+            });
+        });
+
+        describe('when callback attribute has NOT been set', function () {
+            describe('and there were no other event handlers', function () {
+                beforeEach(function () {
+                    template = angular.element('<div><button lazy-validation-on-click></button></div>');
+                    buttonElem = compileDirective(template).find('button');
+                });
+
+                describe('and element has been clicked', function () {
+                    beforeEach(function () {
+                        buttonElem.triggerHandler('click');
+                    });
+
+                    it('should revalidate the form', function () {
+                        expect(lazyValidationController.revalidate).toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe('but there was callback set with ng-click', function () {
+                beforeEach(function () {
+                    template = angular.element('<div><button ng-click="callback()" lazy-validation-on-click></button></div>');
+                    $scope.callback = jasmine.createSpy('callback');
+
+                    buttonElem = compileDirective(template).find('button');
+                });
+
+                it('should trigger callback AFTER revalidate is called', function () {
+                    var validationChange = null;
+
+                    lazyValidationController.revalidate = jasmine.createSpy('revalidate').and.callFake(function () {
+                        // This code should be executed first
+                        validationChange = 'ValidationHasChanged';
+                    });
+
+                    $scope.callback = jasmine.createSpy('callback').and.callFake(function () {
+                        // Assuming this ng-click callback executes AFTER idamValidation.revalidate, this variable should be already updated
+                        expect(validationChange).toBe('ValidationHasChanged');
+                    });
+
+                    buttonElem.triggerHandler('click');
+
+                    expect($scope.callback).toHaveBeenCalled();
+                    expect(lazyValidationController.revalidate).toHaveBeenCalled();
+                });
+            });
+        });
+    });
+})();

--- a/src/app/components/common/form-validation/test/lazy-validation.spec.js
+++ b/src/app/components/common/form-validation/test/lazy-validation.spec.js
@@ -1,0 +1,117 @@
+(function () {
+    'use strict';
+
+    describe('lazy-validation directive', function () {
+        var lazyValidationController, formController, $compile, $scope, template;
+
+        function compileDirective(template) {
+            mockDirectiveController('form', formController, template);
+            return $compile(template)($scope);
+        }
+
+        function mockDirectiveController(directiveName, controller, element) {
+            element.data('$' + directiveName + 'Controller', controller);
+        }
+
+        beforeEach(module('idam-common.form-validation.lazy-validation'));
+
+        beforeEach(module(function ($compileProvider) {
+            $compileProvider.directive('validationTriggerMock', function () {
+                return {
+                    restrict: 'A',
+                    require: '^^lazyValidation',
+                    link: function ($scope, element, attrs, _lazyValidationController_) {
+                        lazyValidationController = _lazyValidationController_;
+                    }
+                };
+            });
+        }));
+
+        beforeEach(inject(function (_$rootScope_, _$compile_) {
+            $scope = _$rootScope_.$new();
+            $compile = _$compile_;
+
+            formController = {
+                $valid: true,
+                someField: '123'
+            };
+        }));
+
+        describe('when it binds form validation to element on a scope', function () {
+            beforeEach(function () {
+                template = angular.element('<div lazy-validation="formValidation"><button validation-trigger-mock /></div>');
+            });
+
+            describe('on initialisation', function () {
+                it('should NOT run validation and NOT bind validation errors', function () {
+                    compileDirective(template);
+
+                    expect($scope.formValidation).toBe(undefined);
+                });
+            });
+
+            describe('after initialisation', function () {
+                beforeEach(function () {
+                    compileDirective(template);
+                });
+
+                describe('when isValid called', function () {
+                    describe('and $valid property on formController is true', function () {
+                        beforeEach(function () {
+                            formController.$valid = true;
+                        });
+
+                        it('should return actual validation status', function () {
+                            expect(lazyValidationController.isValid()).toBe(true);
+                        });
+                    });
+
+                    describe('and $valid property on formController is false', function () {
+                        beforeEach(function () {
+                            formController.$valid = false;
+                        });
+
+                        it('should return actual validation status', function () {
+                            expect(lazyValidationController.isValid()).toBe(false);
+                        });
+                    });
+                });
+
+                describe('when revalidate function called', function () {
+                    beforeEach(function () {
+                        lazyValidationController.revalidate();
+                        $scope.$digest();
+                    });
+
+                    it('should update scope property with validation errors', function () {
+                        expect($scope.formValidation).toEqual(angular.copy(formController));
+                    });
+
+                    describe('and validation changes afterwards', function () {
+                        beforeEach(function () {
+                            formController.$valid = false;
+                            formController.someOtherChange = '123';
+                        });
+
+                        it('should not affect the validation on a scope', function () {
+                            expect($scope.formValidation).not.toEqual(angular.copy(formController));
+                            expect($scope.formValidation.$valid).toBe(true);
+                        });
+
+                        describe('and there was another revalidate() call', function () {
+                            beforeEach(function () {
+                                lazyValidationController.revalidate();
+                                $scope.$digest();
+                            });
+
+                            it('should update scope property', function () {
+                                expect($scope.formValidation).toEqual(angular.copy(formController));
+                                expect($scope.formValidation.$valid).toBe(false);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+})();

--- a/src/app/config/routes.config.json
+++ b/src/app/config/routes.config.json
@@ -25,6 +25,21 @@
       "app/views/lazy/lazy.controller.js",
       "app/components/case/case-example.service.js"
     ]
+  },
+  {
+    "state": "validation-example",
+    "url":"/validation-example",
+    "templateUrl": "app/views/validation-example/validation-example.tpl.html",
+    "pageTitle":"Lazy Loading Example",
+    "permissions": [],
+    "controller": "ValidationExampleController",
+    "controllerAs": "vm",
+    "name": "cpp-ui-spa-master.routes.validation-example",
+    "files":[
+      "app/components/common/form-validation/lazy-validation.directive.js",
+      "app/components/common/form-validation/lazy-validation-on-click.directive.js",
+      "app/components/common/form-validation/form-validation.module.js",
+      "app/views/validation-example/validation-example.controller.js"
+    ]
   }
-
 ]

--- a/src/app/views/validation-example/validation-example.controller.js
+++ b/src/app/views/validation-example/validation-example.controller.js
@@ -1,0 +1,24 @@
+(function () {
+
+    'use strict';
+
+    angular
+        .module('cpp-ui-spa-master.routes.validation-example', ['idam-common.form-validation'])
+        .controller('ValidationExampleController', ValidationExampleController);
+
+    function ValidationExampleController() {
+        var vm = this;
+
+        vm.submitForm = function () {
+            alert('Submit form: This gets called only when form is valid');
+        };
+
+        vm.checkValidationManually = function () {
+            // Check additional criteria before submitting the form
+            if (vm.form.$valid) {
+                vm.submitForm();
+            }
+        };
+    }
+
+}());

--- a/src/app/views/validation-example/validation-example.tpl.html
+++ b/src/app/views/validation-example/validation-example.tpl.html
@@ -1,0 +1,66 @@
+<div>
+    <div class="container">
+        <div class="row">
+            <div class="col-xs-12">
+                <form data-lazy-validation="vm.form" novalidate>
+                    <div class="cpp-form-error-summary"
+                         role="group"
+                         aria-labelledby="error-summary-heading-example-2"
+                         data-ng-show="vm.form.$invalid">
+                        <h3 id="error-summary-heading-example-2">
+                            Required fields are blank
+                        </h3>
+
+                        <p>
+                            Optional description of the error(s) and how to correct them
+                        </p>
+                        <ul class="cpp-form-error-summary-list">
+                            <li data-ng-if="vm.form.fullName.$error.required"><a>Full name must be entered</a></li>
+                            <li data-ng-if="vm.form.fullName.$error.minlength"><a>Full name must be at least 5 characters long</a></li>
+                        </ul>
+                    </div>
+                    <h2>
+                        Your personal details
+                    </h2>
+
+                    <div class="form-group" data-ng-class="{'cpp-form-error': vm.form.fullName.$invalid }">
+                        <label for="example-full-name"
+                               id="error-message-full-name-label">
+                            <span class="form-label-bold">Full name</span>
+                            <span class="form-hint-text">As shown on your birth certificate or passport</span>
+                        </label>
+
+                        <div data-ng-if="vm.form.fullName.$error.required">
+                            <h6 class="cpp-form-error-message">
+                                Full name must be entered
+                            </h6>
+                        </div>
+                        <div data-ng-if="vm.form.fullName.$error.minlength">
+                            <h6 class="cpp-form-error-message">
+                                Full name must be at least 5 characters long
+                            </h6>
+                        </div>
+                        <input class="form-control"
+                               id="example-full-name"
+                               type="text"
+                               name="fullName"
+                               data-ng-model="vm.fullName"
+                               aria-describedby="error-message-full-name-label"
+                               data-ng-required="true"
+                               data-ng-minlength="5">
+                    </div>
+                    <input class="btn btn-default"
+                           type="submit"
+                           value="Submit form"
+                           data-lazy-validation-on-click="vm.submitForm()">
+
+                    <input class="btn btn-default"
+                           type="submit"
+                           value="Submit form (manual validation check)"
+                           data-lazy-validation-on-click
+                           data-ng-click="vm.checkValidationManually()">
+                </form>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Hello,

This is the pull request with two directives I implemented to make angular validation non-dynamic (as the programme requires)

You can see how it works by viewing this URL in application

`#/validation-example`

Basic usage

```
<form lazy-validation="vm.someForm">
   <span ng-if="vm.someForm.name.$error.required">This field is required</span>
   <input type="text" name="name" data-ng-required="true">
   <button lazy-validation-on-click="callbackWhenFormIsValid()" />
</form>
```

What these two directives do is that they updates "vm.someForm" with angular validation results on a specific event (in case of the lazy-validation-on-click its click event on a button) so the validation errors will remain displayed until user subsequently clicks on a button
